### PR TITLE
天気情報の表示

### DIFF
--- a/StudyLayout/weatherViewController.storyboard
+++ b/StudyLayout/weatherViewController.storyboard
@@ -16,19 +16,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="天気情報" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3G1-FF-bc6">
-                                <rect key="frame" x="162" y="124" width="69.333333333333314" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nma-I0-XDT" userLabel="タイトル">
-                                <rect key="frame" x="83" y="173" width="227" height="43"/>
+                                <rect key="frame" x="83" y="167" width="227" height="43"/>
                                 <color key="backgroundColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="43" id="2Pq-Kc-koF"/>
                                     <constraint firstAttribute="width" constant="227" id="wMt-ek-ClN"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="東京の天気情報" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3G1-FF-bc6">
+                                <rect key="frame" x="97" y="118" width="199" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -39,10 +39,10 @@
                         <constraints>
                             <constraint firstItem="nma-I0-XDT" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="83" id="1w6-Lo-puM"/>
                             <constraint firstItem="nma-I0-XDT" firstAttribute="top" secondItem="3G1-FF-bc6" secondAttribute="bottom" constant="28" id="3XE-SP-UdW"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="3G1-FF-bc6" secondAttribute="trailing" constant="161.66999999999999" id="P4F-0Z-nit"/>
-                            <constraint firstItem="3G1-FF-bc6" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="162" id="POo-2A-hiI"/>
+                            <constraint firstItem="3G1-FF-bc6" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="59" id="EeB-eO-jbu"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="3G1-FF-bc6" secondAttribute="trailing" constant="97" id="LV0-Hn-Snm"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="nma-I0-XDT" secondAttribute="trailing" constant="83" id="cfV-mB-yXj"/>
-                            <constraint firstItem="3G1-FF-bc6" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="65" id="zaw-cD-nET"/>
+                            <constraint firstItem="3G1-FF-bc6" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="97" id="sr1-kJ-0Kp"/>
                         </constraints>
                     </view>
                     <connections>

--- a/StudyLayout/weatherViewController.storyboard
+++ b/StudyLayout/weatherViewController.storyboard
@@ -16,9 +16,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3G1-FF-bc6">
-                                <rect key="frame" x="200" y="406" width="42" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="天気情報" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3G1-FF-bc6">
+                                <rect key="frame" x="162" y="124" width="69.333333333333314" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nma-I0-XDT" userLabel="タイトル">
+                                <rect key="frame" x="83" y="173" width="227" height="43"/>
+                                <color key="backgroundColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="43" id="2Pq-Kc-koF"/>
+                                    <constraint firstAttribute="width" constant="227" id="wMt-ek-ClN"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -26,11 +36,23 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="nma-I0-XDT" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="83" id="1w6-Lo-puM"/>
+                            <constraint firstItem="nma-I0-XDT" firstAttribute="top" secondItem="3G1-FF-bc6" secondAttribute="bottom" constant="28" id="3XE-SP-UdW"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="3G1-FF-bc6" secondAttribute="trailing" constant="161.66999999999999" id="P4F-0Z-nit"/>
+                            <constraint firstItem="3G1-FF-bc6" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="162" id="POo-2A-hiI"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="nma-I0-XDT" secondAttribute="trailing" constant="83" id="cfV-mB-yXj"/>
+                            <constraint firstItem="3G1-FF-bc6" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="65" id="zaw-cD-nET"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="weatherTitle" destination="3G1-FF-bc6" id="aBM-gb-9hf"/>
+                        <outlet property="weatherView" destination="nma-I0-XDT" id="8BS-0j-Ybx"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="138" y="5"/>
+            <point key="canvasLocation" x="135.1145038167939" y="4.9295774647887329"/>
         </scene>
     </scenes>
     <resources>

--- a/StudyLayout/weatherViewController.swift
+++ b/StudyLayout/weatherViewController.swift
@@ -18,7 +18,7 @@ class weatherViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         // パラメータの設定
         let parameters = "?lat=35.6809704&lon=35.6809704&appid=\(apiKey)"
         
@@ -45,15 +45,27 @@ class weatherViewController: UIViewController {
                     // JSONオブジェクトの解析
                     let json = try JSON(data: data)
                     
-                    // 天気情報の取得
+                    // 天気情報の取得と結果検証用のデータ
                     if let weatherDescription = json["weather"][0]["description"].string {
                         print("天気予報: \(weatherDescription)")
-                        
-                        // viewのクラッシュを防止し、天気情報を表示させる
-                        DispatchQueue.main.async {
-                            self.weatherView.text = weatherDescription
-                        }
                     }
+                    
+                    // 雲量と天気情報の表示結果の値
+                    let cloudAmount = json["clouds"]["all"]
+                    var weatherForecast = ""
+                    
+                    // 雲量から天気予報の判定
+                    if (cloudAmount < 8.5){
+                        weatherForecast = "晴れです"
+                    }else{
+                        weatherForecast = "曇りです"
+                    }
+                    
+                    // viewのクラッシュを防止し、天気情報を表示させる
+                    DispatchQueue.main.async {
+                        self.weatherView.text = weatherForecast
+                    }
+                    
                 } catch {
                     print("jsonError", error)
                 }

--- a/StudyLayout/weatherViewController.swift
+++ b/StudyLayout/weatherViewController.swift
@@ -9,6 +9,9 @@ import UIKit
 import SwiftyJSON
 
 class weatherViewController: UIViewController {
+    @IBOutlet weak var weatherTitle: UILabel!
+    @IBOutlet weak var weatherView: UILabel!
+    
     // APIのベースURLとAPIキーを設定
     let urlBase = "https://api.openweathermap.org/data/2.5/weather"
     let apiKey = ""
@@ -45,6 +48,11 @@ class weatherViewController: UIViewController {
                     // 天気情報の取得
                     if let weatherDescription = json["weather"][0]["description"].string {
                         print("天気予報: \(weatherDescription)")
+                        
+                        // viewのクラッシュを防止し、天気情報を表示させる
+                        DispatchQueue.main.async {
+                            self.weatherView.text = weatherDescription
+                        }
                     }
                 } catch {
                     print("jsonError", error)


### PR DESCRIPTION
### 関連チケット 
* https://trello.com/c/5HO34df0

### 実装内容 
* 天気APIから天気情報を日本語でVIewに表示させる。

### 備考 
* 天気APIから雨の情報が提供されていないため、今回の表示処理は晴れと曇りのみに限定して行なっています。

### 確認事項 
* weatherViewController.swift
  * 天気APIから、雲量情報を取得していること
  * 雲量の数値に基づいて、条件判定を用いて晴れまたは曇りの判定が出来ていること

### 動作確認事項 
* weatherViewControllerの表示時
  * 天気情報のタイトルが「東京の天気情報」と表示されていること
  * 天気情報が日本語で表示されていること

![Simulator Screenshot - iPhone 14 Pro - 2024-02-02 at 16 54 22](https://github.com/AyumuWB/study_layout/assets/57174543/093be84a-6fd5-4533-8ad8-7cdcc185a900)


